### PR TITLE
Convert toc headings to pydantic basemodel, fix inserting title spans…

### DIFF
--- a/.env_public
+++ b/.env_public
@@ -21,8 +21,13 @@ API_ENDPOINTS = '{
 }'
 
 ADDITIONAL_HEADINGS = '{
-    "frontmatter": ["foreword", "preface", "introduction", "acknowledgements", "blurbs"],
-    "backmatter": ["notes", "colophon"],
+    "frontmatter": [
+        ("foreword", "Foreword"), ("preface", "Preface"), ("introduction", "Introduction"),
+        ("acknowledgements", "Acknowledgements"), ("blurbs", "Summary of Contents"),
+    ],
+    "backmatter": [
+        ("notes", "Endnotes"), ("colophon", "Colophon"),
+    ],
 }'
 
 MATTERS_TO_TEMPLATES_NAMES_MAPPING = '{

--- a/sutta_publisher/src/sutta_publisher/shared/config.py
+++ b/sutta_publisher/src/sutta_publisher/shared/config.py
@@ -40,17 +40,9 @@ def get_edition_config(edition_id: str) -> EditionConfig:
         (target_bio,) = [bio for bio in creators_bios if bio["creator_uid"] == config.publication.creator_uid]
         config.publication.creator_bio = target_bio["creator_biography"]
     except ValueError:
-        # raise SystemExit(f"No creator's biography found for: {config.publication.creator_uid}. Stopping.")
+        raise SystemExit(f"No creator's biography found for: {config.publication.creator_uid}. Stopping.")
 
-        # TODO: DELETE THESE LINES
-        logging.error(f"No creator's biography found for: {config.publication.creator_uid}.")
-        config.publication.creator_bio = {
-            "creator_uid": config.publication.creator_uid,
-            "creator_biography": f"No creator's biography found for: {config.publication.creator_uid}. To be written.",
-        }
-
-    # TODO: UNCOMMENT THIS
-    # config.publication.creator_bio = target_bio["creator_biography"]
+    config.publication.creator_bio = target_bio["creator_biography"]
 
     return config
 

--- a/sutta_publisher/src/sutta_publisher/shared/value_objects/parser_objects.py
+++ b/sutta_publisher/src/sutta_publisher/shared/value_objects/parser_objects.py
@@ -9,43 +9,56 @@ Therefore if we wrap all the parsed data (the output of parsers) into objects ju
 in pydantic objects, they will be more manageable and would have better control over chain of operations executed
 on an object.
 """
-from typing import Any, Optional
+from typing import Any
 
 from bs4 import Tag
 from jinja2 import Template
 from pydantic import BaseModel
 
-from sutta_publisher.edition_parsers.helper_functions import generate_html_toc
+import sutta_publisher.edition_parsers.helper_functions as help_funcs
 
 
 class Blurb(BaseModel):
-    acronym: Optional[str]
-    blurb: Optional[str]
-    name: Optional[str]
-    root_name: Optional[str]
+    acronym: str | None
+    blurb: str | None
+    name: str | None
+    root_name: str | None
     type: str
     uid: str
 
 
+class ToCHeading(BaseModel):
+    acronym: str | None
+    depth: int
+    name: str
+    root_name: str | None
+    tag: Tag
+    type: str
+    uid: str
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
 class MainTableOfContents(BaseModel):
-    headings: list[dict]
+    headings: list[ToCHeading]
 
     def to_html_str(self, template: Template) -> str:
 
-        return template.render(main_toc=generate_html_toc(self.headings))
+        return template.render(main_toc=help_funcs.generate_html_toc(self.headings))
 
     class Config:
         arbitrary_types_allowed = True
 
 
 class SecondaryTablesOfContents(BaseModel):
-    headings: dict[Tag, list[dict]]
+    headings: dict[Tag, list[ToCHeading]]
 
     def to_html_str(self, template: Template) -> dict[Tag, str]:
         tocs: dict[Tag, str] = {}
 
         for _target, _toc in self.headings.items():
-            tocs[_target] = template.render(secondary_toc=generate_html_toc(_toc))
+            tocs[_target] = template.render(secondary_toc=help_funcs.generate_html_toc(_toc))
 
         return tocs
 


### PR DESCRIPTION
…, minor improvements

# When merged this PR will:
- convert ToC headings from dict to Pydantic BaseModels,
- change data source for sutta's translated titles
- restore raise exception if creator's biography is not found