### PR TITLE
Epub split mainmatter into separate xhtml files

### DIFF
--- a/sutta_publisher/src/sutta_publisher/edition_parsers/base.py
+++ b/sutta_publisher/src/sutta_publisher/edition_parsers/base.py
@@ -225,8 +225,8 @@ class EditionParser(ABC):
 
         validate_node(node)
 
-        # Some nodes are branches not leaves - they contain preheadings/headings but no mainmatter, we skip them.
-        if not node.mainmatter.markup:
+        # Some nodes are branches or empty leaves - they contain preheadings/headings but no mainmatter, we skip them.
+        if node.type == "branch" or not node.mainmatter.markup:
             return ""
 
         else:
@@ -320,7 +320,12 @@ class EditionParser(ABC):
 
         # Add <span> tags with acronyms, translated and root titles into sutta-title headings
         _sutta_headings: list[Tag] = [h for h in _headings if h.name == f"h{_sutta_title_depth}"]
-        _sutta_nodes: list[Node] = [_node for _part in _raw_data.mainmatter for _node in _part if _node.type == "leaf"]
+        _sutta_nodes: list[Node] = [
+            _node
+            for _part in _raw_data.mainmatter
+            for _node in _part
+            if _node.type == "leaf" and _node.mainmatter.markup
+        ]
         self._insert_span_tags(headings=_sutta_headings, nodes=_sutta_nodes)
 
         # Add class "subheading" for all HTML headings below hX with class "sutta-title"

--- a/sutta_publisher/src/sutta_publisher/shared/value_objects/edition_data.py
+++ b/sutta_publisher/src/sutta_publisher/shared/value_objects/edition_data.py
@@ -90,7 +90,7 @@ class VolumeData:
     headings: VolumeHeadings
     # Return the mainmatter for a volume mainmatter
     mainmatter: MainMatter
-    tree: list[dict]
+    tree: list[dict | str]
     depths: dict[str, int]
 
     # `extras` - return all files that pertain to an edition as key:value pairs,

--- a/sutta_publisher/src/sutta_publisher/templates/book-template.html
+++ b/sutta_publisher/src/sutta_publisher/templates/book-template.html
@@ -64,10 +64,11 @@
     <meta name="DC.Source" content="{{source_url | safe}}">
     <meta name="DC.Creator" content="{{creator_name | safe}}">
     <meta name="DC.Contributor" content="{{creator_name | safe}}">
+    <title>{{translation_title | safe}}</title>
     <style>{{css | safe}}</style>
 </head>
 
-<body>
+<body id="{{acronym | lower | safe}}">
     <section id='frontmatter'>{% for matter in frontmatter %}{{matter | safe}}{% endfor %}</section>
     <section id='mainmatter'>{{mainmatter | safe}}</section>
     <section id='backmatter'>{% for matter in backmatter %}{{matter | safe}}{% endfor %}</section>


### PR DESCRIPTION
#### Task: [EPUB] split mainmatter chapter into smaller parts


#### When merged, this PR will:
- fix generating base html if mainmatter contains more than one part
- add support for empty leaves
- add splitting mainmatter chapter into smaller parts,
- add support for all relative links (main toc, secondary tocs, blurbs, endnotes)
