### PR TITLE
Add zipping paperback files, fix bug with blurb titles in paperback

### DIFF
--- a/sutta_publisher/src/sutta_publisher/edition_parsers/latex.py
+++ b/sutta_publisher/src/sutta_publisher/edition_parsers/latex.py
@@ -405,7 +405,7 @@ class LatexParser(EditionParser):
             case "a" if tag.has_attr("role") and "doc-noteref" in tag["role"]:
                 return self._append_footnote()
 
-            case "a" if tag.has_attr("href"):
+            case "a" if tag.has_attr("href") and (not tag.has_attr("class") or "blurb-link" not in tag["class"]):
                 return self._append_href(tag=tag)
 
             case "article" if tag.has_attr("class") and "epigraph" in tag["class"]:

--- a/sutta_publisher/src/sutta_publisher/edition_parsers/paperback.py
+++ b/sutta_publisher/src/sutta_publisher/edition_parsers/paperback.py
@@ -46,23 +46,26 @@ class PaperbackEdition(LatexParser):
     def _generate_flat_background_image(self, volume: Volume) -> None:
         log.debug(f"Generating flat background image...")
 
-        _background_path = self.TEMP_DIR / "background-image"
-        _background_doc = self._generate_cover(
+        _path = self.TEMP_DIR / "background-image"
+        log.debug("Generating tex...")
+        doc = self._generate_cover(
             volume=volume, preamble="background-preamble", body="background-body", template_dir="background"
         )
-        _background_doc.generate_pdf(
-            filepath=str(_background_path), clean_tex=False, compiler="latexmk", compiler_args=["-lualatex"]
-        )
-        with Image(filename=f"pdf:{_background_path.with_suffix('.pdf')}", resolution=self.IMAGE_DENSITY) as img:
+        # doc.generate_tex(filepath=str(_path))  # dev
+        log.debug("Generating pdf...")
+        doc.generate_pdf(filepath=str(_path), clean_tex=False, compiler="latexmk", compiler_args=["-lualatex"])
+
+        with Image(filename=f"pdf:{_path.with_suffix('.pdf')}", resolution=self.IMAGE_DENSITY) as img:
             img.format = "jpg"
             img.compression_quality = self.IMAGE_QUALITY
-            img.save(filename=_background_path.with_suffix(".jpg"))
+            img.save(filename=_path.with_suffix(".jpg"))
 
     def generate_cover(self, volume: Volume) -> None:
         log.debug(f"Generating cover... (vol {volume.volume_number or 1} of {self.config.edition.number_of_volumes})")
 
         self._generate_flat_background_image(volume=volume)
 
+        log.debug("Generating final cover...")
         _path = self.TEMP_DIR / volume.cover_filename
         log.debug("Generating tex...")
         doc = self._generate_cover(

--- a/sutta_publisher/src/sutta_publisher/shared/publisher.py
+++ b/sutta_publisher/src/sutta_publisher/shared/publisher.py
@@ -1,6 +1,8 @@
 import logging
 import os
+from pathlib import Path
 
+from sutta_publisher.edition_parsers.helper_functions import make_paperback_zip_files
 from sutta_publisher.shared import EDITIONS_REPO_URL, REPO_PATTERN
 from sutta_publisher.shared.github_handler import upload_files_to_repo
 from sutta_publisher.shared.value_objects.edition import EditionResult
@@ -9,20 +11,25 @@ log = logging.getLogger(__name__)
 
 
 def publish(result: EditionResult, api_key: str) -> None:
-    for idx, volume in enumerate(result.volumes):
-        volume_info = f"(vol {idx + 1} of {len(result.volumes)}) " if len(result.volumes) > 1 else ""
-        log.info(
-            f"Publishing {result.translation_title}... {volume_info}[{result.publication_type}]\n"
-            f"Files: {', '.join(_path.name for _path in volume)}"
-        )
+    file_paths: list[Path] = [_path for _volume in result.volumes for _path in _volume]
 
-        if not os.getenv("PYTHONDEBUG", ""):
-            upload_files_to_repo(
-                edition=result,
-                file_paths=volume,
-                repo_url=EDITIONS_REPO_URL,
-                repo_path=REPO_PATTERN.format(**result.dict()),
-                api_key=api_key,
-            )
+    if result.publication_type == "paperback":
+        _zip_paths = make_paperback_zip_files(paths=file_paths, num_of_volumes=len(result.volumes))
+        file_paths = _zip_paths
+
+    volumes_info = f"({len(result.volumes)} volumes) " if len(result.volumes) > 1 else ""
+    log.info(
+        f"Publishing {result.translation_title}... {volumes_info}[{result.publication_type}]\n"
+        f"Files: {', '.join(_path.name for _path in file_paths)}"
+    )
+
+    if not os.getenv("PYTHONDEBUG", ""):
+        upload_files_to_repo(
+            edition=result,
+            file_paths=file_paths,
+            repo_url=EDITIONS_REPO_URL,
+            repo_path=REPO_PATTERN.format(**result.dict()),
+            api_key=api_key,
+        )
 
     log.info("** Publication uploaded successfully! **")

--- a/sutta_publisher/tests/unit/test_latex_parser.py
+++ b/sutta_publisher/tests/unit/test_latex_parser.py
@@ -141,6 +141,11 @@ def latex_edition(data, config):
         ("<ul><li>Test 1</li></ul>", "\\begin{itemize}%\n\\item Test 1%\n\\end{itemize}\n\n"),
         # individual characters
         ("<test>Test & test _ test ~ test</test>", "Test \\& test \\_ test \\textasciitilde test"),
+        # full blurb item
+        (
+            "<a class='blurb-link' href='#mn'><span class='blurb-label'><span class='blurb-item translated-title'>Middle Discourses Collection </span><span class='blurb-item root-title'>Majjhimanikāya</span></span></a>",
+            "Middle Discourses Collection (\\textit{\\textsanskrit{Majjhimanikāya}})",
+        ),
     ],
 )
 def test_process_tag(doc, latex_edition, html, expected):


### PR DESCRIPTION
#### When merged, this PR will:
- Add zipping paperback files into 3 zip files before pushing to Editions repo
- Reduce number of commits to 1 per each edition
- Fix bug with None in blurb titles in paperback edition
